### PR TITLE
lwip dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "couleurs": "^5.0.0",
-    "lwip": "^0.0.7",
+    "lwip": "^0.0.8",
     "minimist": "^1.1.3",
     "window-size": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asciify-image",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Convert images to ASCII art without native dependencies",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- updated `lwip` dependency to v0.0.8 (v0.0.7 breaks on build on install due to changes in v8 engine in current Node versions)
- pushed module's patch version number to reflect these changes