### PR TITLE
Feature: Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,12 @@ really need to change this.
 #### callback
 
 The function to call after the image is asciified. Receives the asciified text
-as a parameter.
+as a parameter.  
+When omitted, the module will return a Promise ([example](#using-promises)).
 
-## Example
+## Examples
+
+#### Using Callback Functions
 
 ```js
 var asciify = require('asciify-image');
@@ -111,6 +114,28 @@ asciify('path/to/image.png', options, function (asciified) {
   // Print to console
   console.log(asciified);
 });
+```
+
+#### Using Promises
+
+```js
+var asciify = require('asciify-image');
+
+var options = {
+  fit:    'box',
+  width:  200,
+  height: 100
+}
+
+asciify('path/to/image.png', options)
+  .then(function onResolve (asciified) {
+    // Print to console
+    console.log(asciified);
+  })
+  .catch(function onReject (reason) {
+    // Print rejection reason to console
+    console.error(reason);
+  });
 ```
 
 ## How It Works

--- a/cli.js
+++ b/cli.js
@@ -49,15 +49,17 @@ var options = {
 
 var size = require('window-size');
 
+var errorOutput = function(message) {
+  console.log(message);
+  process.exit(1);
+}
+
 // Setup defaults just for CLI
 if (!options.fit)    options.fit    = 'box';
 if (!options.width)  options.width  = size.width;
 if (!options.height) options.height = size.height;
 
-if (!argv._[0]) {
-  console.log('You must provide an image');
-  process.exit(1);
-}
+if (!argv._[0])      errorOutput('You must provide an image');
 
 // Call the module
-require('./index')(argv._[0], options, console.log);
+require('./index')(argv._[0], options).then(console.log).catch(errorOutput);


### PR DESCRIPTION
In a current project I included `asciify-image` within a chain of [Promises](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects) and realized, there is no way to handle possible failures in an acceptable manner within this chain.

Therefore, I partially rewrote the module:

1. The module's [core functionality has been outsourced into a separate function](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/index.js#L53-L114).

2. [Support another, fourth argument](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/index.js#L11) (an optional `onErrorCallback` function).  
When omitted, [the `asciify_core` function will be given `console.log` as `onErrorCallback`](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/index.js#L40) to ensure the functionality remains the same as before.

3. [Return a Promise](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/index.js#L33-L37) when the module's callback function argument(s) is/are omitted.  

The cli has been slightly changed, to

- [Show off the usage of the Promise based approach](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/cli.js#L64-L65).

- [Return a proper exit code on failure](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/cli.js#L52-L55).

README.md has been [updated to reflect these changes](https://github.com/ta2edchimp/asciify-image/blob/feature/promises/README.md#callback).

I _did not_ make any changes to the `package.json` / versioning.

—

Let me know what you think about the proposed changes.
