### PR TITLE
Switch image processor from lwip to jimp

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "couleurs": "^5.0.0",
-    "lwip": "0.0.9",
+    "jimp": "^0.2.28",
     "minimist": "^1.1.3",
     "window-size": "^0.1.2"
   },


### PR DESCRIPTION
Hi there! Great module, however I think that [Jimp](https://github.com/oliver-moran/jimp) would be a much better fit as an image processor than lwip.

First, in the readme you claim that asciify-image doesn't require any native dependencies, however it depends on lwip which [depends on](https://github.com/EyalAr/lwip#installation) [graphicsmagick](http://www.graphicsmagick.org/).
**Jimp is truly 100% Javascript**.

Second, [lwip has some issues with modern versions of Node](https://github.com/EyalAr/lwip/issues/297) which means that the current version of asciify-image can only be installed on older versions of Node.
**Jimp runs on most (if not all) versions of Node**.

Luckily, the APIs for lwip and Jimp are **very** similar and it required very little changes to switch over, better yet, it didn't require any changes to the asciify-image API.

This all came to be from a [discussion](https://github.com/kodie/npm-gif/issues/3) a few of us were having on a project of mine where we were talking about implementing asciify-image into the project.

Let me know what you think. Thanks!