### PR TITLE
Fix issue with setting images to 100% width of terminal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and as a CLI tool. Use the `-h` or `--help` flag to see more about the CLI tool.
 
 #### path
 
-The path to the image you wish to asciify. Currently supported formats are:
+The file path, URL, or buffer for the image you wish to asciify. Currently supported formats are:
 
 * JPG
 * PNG
@@ -69,13 +69,13 @@ The fit to which to resize the image:
 
 *Default: original image width, CLI default: window width*
 
-The width to which to resize the image.
+The width to which to resize the image. Use a percentage to set the image width to `x%` of the terminal window width.
 
 #### options.height
 
 *Default: original image height, CLI default: window height*
 
-The height to which to resize the image.
+The height to which to resize the image. Use a percentage to set the image height to `x%` of the terminal window height.
 
 #### options.format
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npm install -g asciify-image
 ## API
 
 This API applies to asciify-image both as a Node.js module ([example](#example))
-and as a CLI tool. Use the `-h` or `--help` flag to see more about the CLI tool.
+and as a CLI tool. Use the `-?` or `--help` flag to see more about the CLI tool.
 
 #### path
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ really need to change this.
 
 #### callback
 
-The function to call after the image is asciified. Receives the asciified text
-as a parameter.  
+The function to call after the image is asciified. Receives any errors that
+occurred as the first parameter and the asciified text as the second.  
 When omitted, the module will return a Promise ([example](#using-promises)).
 
 ## Examples
@@ -110,7 +110,9 @@ var options = {
   height: 100
 }
 
-asciify('path/to/image.png', options, function (asciified) {
+asciify('path/to/image.png', options, function (err, asciified) {
+  if (err) throw err;
+
   // Print to console
   console.log(asciified);
 });

--- a/cli.js
+++ b/cli.js
@@ -47,8 +47,6 @@ var options = {
   width:   argv['width']
 }
 
-var size = require('window-size');
-
 var errorOutput = function(message) {
   console.log(message);
   process.exit(1);
@@ -56,8 +54,8 @@ var errorOutput = function(message) {
 
 // Setup defaults just for CLI
 if (!options.fit)    options.fit    = 'box';
-if (!options.width)  options.width  = size.width;
-if (!options.height) options.height = size.height;
+if (!options.width)  options.width  = '100%';
+if (!options.height) options.height = '100%';
 
 if (!argv._[0])      errorOutput('You must provide an image');
 

--- a/cli.js
+++ b/cli.js
@@ -9,8 +9,7 @@ var m_opts = {
     'fit':     'f',
     'height':  'h',
     'width':   'w',
-
-    'help':    'h'
+    'help':    '?'
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -10,36 +10,32 @@ var Jimp     = require('jimp'),
 var chars = ' .,:;i1tfLCG08@',
     num_c = chars.length - 1;
 
-module.exports = function (path, second, third, fourth) {
+module.exports = function (path, second, third) {
   // Organize arguments
   var opts          = {},
-      onSuccess,
-      onFailure;
+      callback;
 
   if (typeof second === 'object') {
     opts = second;
     if (typeof third === 'function') {
-      onSuccess = third;
-      if (typeof fourth === 'function') {
-        onFailure = fourth;
-      }
+      callback = third;
     }
   } else if (typeof second === 'function') {
-    onSuccess = second;
-    if (typeof third === 'function') {
-      onFailure = third;
-    }
+    callback = second;
   }
 
   // If no callback is specified, prepare a promise to return ...
-  if (!onSuccess) {
+  if (!callback) {
     return new Promise(function(resolve, reject) {
-      asciify_core(path, opts, resolve, reject);
+      asciify_core(path, opts, function(err, success) {
+        if (err) return reject(err);
+        if (success) return resolve(success);
+      });
     });
   }
 
   // ... else proceed as usual
-  asciify_core(path, opts, onSuccess, onFailure || console.log);
+  asciify_core(path, opts, callback || console.log);
 }
 
 /**
@@ -52,10 +48,10 @@ module.exports = function (path, second, third, fourth) {
  *
  * @returns [void]
  */
-var asciify_core = function(path, opts, onSuccess, onFailure) {
+var asciify_core = function(path, opts, callback) {
   // First open image to get initial properties
   Jimp.read(path, function(err, image) {
-    if (err) return onFailure('Error loading image: ' + err);
+    if (err) return callback('Error loading image: ' + err);
 
     // Setup options
     var options = {
@@ -108,7 +104,7 @@ var asciify_core = function(path, opts, onSuccess, onFailure) {
       if (options.as_string && j != image.bitmap.height - 1) ascii += '\n';
     }
 
-    onSuccess(ascii);
+    callback(null, ascii);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -53,11 +53,21 @@ var asciify_core = function(path, opts, callback) {
   Jimp.read(path, function(err, image) {
     if (err) return callback('Error loading image: ' + err);
 
+    // Percentage based widths
+    if (opts.width && opts.width.substr(-1) === '%') {
+      opts.width = Math.floor((parseInt(opts.width.slice(0, -1)) / 100) * (windowSize.width * terminalCharWidth));
+    }
+
+    // Percentage based heights
+    if (opts.height && opts.height.substr(-1) === '%') {
+      opts.height = Math.floor((parseInt(opts.height.slice(0, -1)) / 100) * windowSize.height);
+    }
+
     // Setup options
     var options = {
       fit:     opts.fit     ? opts.fit               : 'original',
-      width:   opts.width   ? (opts.width.substr(-1) === '%' ? Math.floor((parseInt(opts.width.slice(0, -1)) / 100) * (windowSize.width * terminalCharWidth)) : parseInt(opts.width)) : image.bitmap.width,
-      height:  opts.height  ? (opts.height.substr(-1) === '%' ? Math.floor((parseInt(opts.height.slice(0, -1)) / 100) * windowSize.height) : parseInt(opts.height)) : image.bitmap.height,
+      width:   opts.width   ? parseInt(opts.width)   : image.bitmap.width,
+      height:  opts.height  ? parseInt(opts.height)  : image.bitmap.height,
       c_ratio: opts.c_ratio ? parseInt(opts.c_ratio) : 2,
 
       color:      opts.color  == false    ? false : true,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var Jimp     = require('jimp'),
-    Couleurs = require('couleurs');
+    Couleurs = require('couleurs'),
+    terminalCharWidth = require('terminal-char-width'),
+    windowSize = require('window-size');
 
 // Set of basic characters ordered by increasing "darkness"
 // Used as pixels in the ASCII image
@@ -58,8 +60,8 @@ var asciify_core = function(path, opts, onSuccess, onFailure) {
     // Setup options
     var options = {
       fit:     opts.fit     ? opts.fit               : 'original',
-      width:   opts.width   ? parseInt(opts.width)   : image.bitmap.width,
-      height:  opts.height  ? parseInt(opts.height)  : image.bitmap.height,
+      width:   opts.width   ? (opts.width.substr(-1) === '%' ? (parseInt(opts.width.slice(0, -1)) / 100) * (windowSize.width * terminalCharWidth) - 1 : parseInt(opts.width)) : image.bitmap.width,
+      height:  opts.height  ? (opts.height.substr(-1) === '%' ? (parseInt(opts.height.slice(0, -1)) / 100) * windowSize.height : parseInt(opts.height)) : image.bitmap.height,
       c_ratio: opts.c_ratio ? parseInt(opts.c_ratio) : 2,
 
       color:      opts.color  == false    ? false : true,

--- a/index.js
+++ b/index.js
@@ -60,8 +60,8 @@ var asciify_core = function(path, opts, onSuccess, onFailure) {
     // Setup options
     var options = {
       fit:     opts.fit     ? opts.fit               : 'original',
-      width:   opts.width   ? (opts.width.substr(-1) === '%' ? (parseInt(opts.width.slice(0, -1)) / 100) * (windowSize.width * terminalCharWidth) - 1 : parseInt(opts.width)) : image.bitmap.width,
-      height:  opts.height  ? (opts.height.substr(-1) === '%' ? (parseInt(opts.height.slice(0, -1)) / 100) * windowSize.height : parseInt(opts.height)) : image.bitmap.height,
+      width:   opts.width   ? (opts.width.substr(-1) === '%' ? Math.floor((parseInt(opts.width.slice(0, -1)) / 100) * (windowSize.width * terminalCharWidth)) : parseInt(opts.width)) : image.bitmap.width,
+      height:  opts.height  ? (opts.height.substr(-1) === '%' ? Math.floor((parseInt(opts.height.slice(0, -1)) / 100) * windowSize.height) : parseInt(opts.height)) : image.bitmap.height,
       c_ratio: opts.c_ratio ? parseInt(opts.c_ratio) : 2,
 
       color:      opts.color  == false    ? false : true,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "couleurs": "^5.0.0",
     "jimp": "^0.2.28",
     "minimist": "^1.1.3",
+    "terminal-char-width": "^1.0.8",
     "window-size": "^0.1.2"
   },
   "devDependencies": {},


### PR DESCRIPTION
This PR takes care of a few things actually:

1. Fixes Issue #5.
2. Fixes bug where `height` could not be set via the CLI tool as both the `height` and `help` options were using the shorthand `h`. `help` now uses the shorthand `?`.
3. Percentage based values can now be used with `width` and `height` options. Using percentage based values will make the images be `x%` of the terminal window's width or height respectively.
4. Documentation for using URLs and buffers as well as file paths for images as well as the percentage based values mentioned above.
5. Switches to a more traditional callback style. For example:

Instead of this: (which wasn't even fully documented)
```javascript
asciify('path/to/image.png', options, function (asciified) {
  console.log(asciified);
}, function (err) {
   console.log(err);
});
```

It'll work like this:
```javascript
asciify('path/to/image.png', options, function (err, asciified) {
  if (err) throw err;
  console.log(asciified);
});
```

Most modules expect callbacks to work this way and now we'll be able to use this in combination with modules such as [deasync](https://github.com/abbr/deasync)!

Unfortunately this is a slightly breaking change however seeing as this module still isn't even at version 1.0 yet I figured it wouldn't be a bad idea.